### PR TITLE
Fix typo removeSuffix -> removedSuffix

### DIFF
--- a/Sources/SparrowKit/Foundation/StringExtension.swift
+++ b/Sources/SparrowKit/Foundation/StringExtension.swift
@@ -159,7 +159,7 @@ public extension String {
      
      - parameter suffix: String which need remove.
      */
-    func removeSuffix(_ suffix: String) -> String {
+    func removedSuffix(_ suffix: String) -> String {
         if self.hasSuffix(suffix) {
             return String(dropLast(suffix.count))
         } else {


### PR DESCRIPTION
In StringExtension.swift,
`func removeSuffix(_ suffix: String) -> String` is renamed to be consistent with 
`func removedPrefix(_ prefix: String) -> String`