### PR TITLE
Fix typo in SPImageView.swift

### DIFF
--- a/Sources/SparrowKit/UIKit/Classes/SPImageView.swift
+++ b/Sources/SparrowKit/UIKit/Classes/SPImageView.swift
@@ -57,7 +57,7 @@ open class SPImageView: UIImageView {
      SparrowKit: Wrapper of init.
      Called in each init and using for configuration.
      
-     No need ovveride init. Using one function for configurate view.
+     No need override init. Using one function for configurate view.
      */
     open func commonInit() {}
 }


### PR DESCRIPTION
## Goal
<!--- Provide details about reason changes. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [] Testing in compability platforms
- [] Installed correct via `Swift Package Manager` and `Cocoapods`
