### PR TITLE
Mirror+ReflectProperties extension

### DIFF
--- a/Sources/SwiftBoost/Foundation/Extensions/MirrorExtension.swift
+++ b/Sources/SwiftBoost/Foundation/Extensions/MirrorExtension.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension Mirror {
+    /**
+     This static method iterates over properties of a given object, applying a closure to each property that matches the specified type.
+
+     - Parameters:
+       - target: The object whose properties will be reflected.
+       - type: The type of properties to which the closure should be applied. By default, it's `T.self`.
+       - recursively: If set to `true`, the method will reflect properties of the target's properties recursively. Default value is `false`.
+       - closure: The closure to apply to each property of the specified type. The closure takes a parameter of type `T`.
+
+     - Note: This function uses **Swift's Mirror API** for reflection. Not all properties may be accessible for types that do not fully support reflection.
+     
+     Exmaple usage:
+     ```
+     class MyClass {
+        var myIntProperty: Int = 0
+        var myStringProperty: String = "Hello"
+     }
+
+     let myInstance = MyClass()
+     Mirror.reflectProperties(of: myInstance, matchingType: Int.self) { property in
+        print("The value of myIntProperty is (property)")
+     }
+     ```
+     */
+    public static func reflectProperties<T>(
+        of target: Any,
+        matchingType type: T.Type = T.self,
+        recursively: Bool = false,
+        using closure: (T) -> Void
+    ) {
+        let mirror = Mirror(reflecting: target)
+        
+        for child in mirror.children {
+            (child.value as? T).map(closure)
+            guard recursively else { continue }
+            
+            Mirror.reflectProperties(
+                of: child.value,
+                recursively: true,
+                using: closure
+            )
+        }
+    }
+}


### PR DESCRIPTION
Hello, I've added an extension that introduces a static method for iterating over the properties of a specified object. This function applies a user-defined closure to each property that matches a certain type, significantly enhancing our code's flexibility and adaptability.

Here's a brief overview of the features of this function:

- It allows specifying the object whose properties are to be reflected (the 'target').
- The type of properties to which the closure should be applied can be specified. By default, it's `T.self`.
- There's an option to reflect the properties of the target's properties recursively.
- Users can provide a closure to be applied to each property of the specified type.
- It's important to note that this function leverages **Swift's Mirror API** for reflection. As such, some properties may not be accessible for types that do not fully support reflection.

I believe this extension will significantly enhance our ability to manipulate and interact with object properties. 

Best Regards,
Astemir