### PR TITLE
use debugPrint instead of print

### DIFF
--- a/Sources/SwiftBoost/Foundation/Logger.swift
+++ b/Sources/SwiftBoost/Foundation/Logger.swift
@@ -38,7 +38,7 @@ public enum Logger {
                 break
             }
             
-            print(formattedMessage)
+            debugPrint(formattedMessage)
         }
     }
     


### PR DESCRIPTION
## Goal
debugPrint provides more detailed and descriptive output for complex objects, making it ideal for debugging. It is intended specifically for developer-facing logs and can be configured to suppress output in release builds, unlike print.
